### PR TITLE
Levi's edits after attempting replication on Princeton's cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+data/
+
 # History files
 .Rhistory
 .Rapp.history

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 data/
+results/
 
 # History files
 .Rhistory

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Scripts in this repository are written in Python, Stata, and R. Throughout this 
 │   ├── 0_env_setup
 │   │   └── setup.R
 │   ├── 1_cleaning
-│   │   ├── 01_country_crosswalk.R
-│   │   ├── 02_crop_crosswalk.R
+│   │   ├── 01_country_crosswalk.py
+│   │   ├── 02_crop_crosswalk.py
 │   │   ├── 03_build_tradedata.py
 │   │   ├── 04_build_proddata.py
 │   │   ├── 05_fill_tradedata.do
@@ -133,8 +133,8 @@ The code was last run on a Linux terminal with Stata, R, and Python. The followi
 ## Instructions for replication
 The analysis for this project can be fully replicated (from start to end) using the bash script `code/run.sh`. To do so, the replicator must install the software requirements detailed above and place the path of their working directory on line 18 of the bash script before executing it.
 However, if the replicator wishes to only run the code partially or script by script, the programs should be executed in the following order (after setting the correct working directory):
-1. `code/1_cleaning/01_country_crosswalk.R` creates a country name crosswalk used in later scripts.
-2. `code/1_cleaning/02_crop_crosswalk.R` creates a crop crosswalk used in later scripts.
+1. `code/1_cleaning/01_country_crosswalk.py` creates a country name crosswalk used in later scripts.
+2. `code/1_cleaning/02_crop_crosswalk.py` creates a crop crosswalk used in later scripts.
 3. `code/1_cleaning/03_build_tradedata.py` cleans trade data from BACI/COMTRADE.
 4. `code/1_cleaning/04_build_proddata.py` cleans production data from the FAO.
 5. `code/1_cleaning/05_fill_tradedata.do` fills trade data with auto-consumption.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ Scripts in this repository are written in Python, Stata, and R. Throughout this 
 │   │   │   └── gaez.csv
 │   │   ├── grace
 │   │   │   └── grace.dta
-│   │   ├── gaez
-│   │   │   └── gaez.csv
 │   │   ├── hand
 │   │   │   ├── caf_gaezpy_crosswalk.csv
 │   │   │   ├── fao_country_crosswalk.csv
@@ -125,10 +123,10 @@ The code was last run on a Linux terminal with Stata, R, and Python. The followi
 | `data/input/faostat/Prices_E_All_Data_(Normalized).csv` `data/input/faostat/Production_Crops_Livestock_E_All_Data_(Normalized).csv` `data/input/faostat/Value_of_Production_E_All_Data_(Normalized).csv` | FAOSTAT Data Download interface to download the [QCL](https://www.fao.org/faostat/en/#data/QCL) and [QV](https://www.fao.org/faostat/en/#data/QV) data series for all countries. |
 | `data/input/gaez/gaez.csv` | Crosswalk between [GAEZ (v4) Agro-climatic Potential Yield](https://gaez.fao.org/pages/theme-details-theme-3) fields and GRACE cells from [Carleton, Crews and Nath (2024)](https://www.levicrews.com/files/p-wateruse_paper.pdf). |
 | `data/input/grace/grace.dta` | GRACE data from [Carleton, Crews and Nath (2024)](https://www.levicrews.com/files/p-wateruse_paper.pdf). GRACE cells are merged with groundwater levels estimates from [Fan, Li and Miguez-Macho (2013)](https://www.science.org/doi/10.1126/science.1229881), gridded cropped area fraction data from [Monfreda et al. (2008)](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2007GB002947) and from [Ramankutty et al. (2008)](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2007GB002952), and cumulative precipitation from the Global Metorological Forcing Dataset . The croppped area fraction data was accessed through the [SAGE portal](https://sage.nelson.wisc.edu/data-and-models/datasets/#globaluse). |
-| `data/hand/caf_gaezpy_crosswalk.csv` | Crosswalk of crop names between GAEZ v4 and cropped area fraction data. |
-| `data/hand/fao_country_crosswalk.csv` | Obtained from [deprecated FAO link](https://www.fao.org/countryprofiles/iso3list/en/). |
-| `data/hand/FCL_HS_mappings_2020-01-07.csv` | Downloaded from [deprecated FAO link](http://datalab.review.fao.org/datalab/caliper/web/sites/default/files/2020-01/FCL_HS_mappings_2020-01-07.csv). |
-| `data/nra/AgIncentivesNRP.csv` `data/nra/UpdatedDistortions_to_AgriculturalIncentives_database_0613.xls` | Obtained through the [AgIncentives Database](agincentives.org). |
+| `data/input/hand/caf_gaezpy_crosswalk.csv` | Crosswalk of crop names between GAEZ v4 and cropped area fraction data. |
+| `data/input/hand/fao_country_crosswalk.csv` | Obtained from [deprecated FAO link](https://www.fao.org/countryprofiles/iso3list/en/). |
+| `data/input/hand/FCL_HS_mappings_2020-01-07.csv` | Downloaded from [deprecated FAO link](http://datalab.review.fao.org/datalab/caliper/web/sites/default/files/2020-01/FCL_HS_mappings_2020-01-07.csv). |
+| `data/input/nra/AgIncentivesNRP.csv` `data/input/nra/UpdatedDistortions_to_AgriculturalIncentives_database_0613.xls` | Obtained through the [AgIncentives Database](agincentives.org). |
 
 ## Instructions for replication
 The analysis for this project can be fully replicated (from start to end) using the bash script `code/run.sh`. To do so, the replicator must install the software requirements detailed above and place the path of their working directory on line 18 of the bash script before executing it.

--- a/code/run.sh
+++ b/code/run.sh
@@ -5,7 +5,7 @@
 # load necessary modules here (if necessary)
 # module load ...
 
-# python packages
+echo "install python packages"
 pip install numpy
 pip install pandas
 pip install fuzzywuzzy
@@ -14,53 +14,53 @@ pip install openpyxl
 
 # SET WORKING DIRECTORY HERE -----------------------------------------
 
-# insert the path of your working directory after "cd"  
-cd 
+# insert the path of your working directory after "cd"
+cd /scratch/network/lcrews/ccn-water-PandP
 
 # CLEAN VIRTUAL WATER DATA -------------------------------------------
 
-# create country crosswalk
+echo "create country crosswalk"
 python code/1_cleaning/01_country_crosswalk.py
 
-# create crop crosswalk
+echo "create crop crosswalk"
 python code/1_cleaning/02_crop_crosswalk.py
 
-# wrangle trade data from BACI/COMTRADE
+echo "wrangle trade data from BACI/COMTRADE"
 python code/1_cleaning/03_build_tradedata.py
 
-# clean production data from the FAO
+echo "clean production data from the FAO"
 python code/1_cleaning/04_build_proddata.py
 
-# merge trade data
+echo "merge trade data"
 stata -b do code/1_cleaning/05_fill_tradedata.do
 
-# create virtual water flows estimates
+echo "create virtual water flows estimates"
 python code/1_cleaning/06_virtualwater.py
 
-# create global water use estimates per crop
+echo "create global water use estimates per crop"
 stata -b do code/1_cleaning/07_crop_water_use.do
 
-# merge grace and gaez
+echo "merge grace and gaez"
 Rscript code/1_cleaning/08_merge_grace_gaezpy.R
 
-# merge grace and ag employment data
+echo "merge grace and ag employment data"
 Rscript code/1_cleaning/09_merge_grace_agemp.R
 
-# merge grace and virtual water flows
+echo "merge grace and virtual water flows"
 Rscript code/1_cleaning/10_merge_grace_virtwflows.R
 
 # MAKE FIGURES --------------------------------------------------------
 
-# make maps
+echo "make maps"
 Rscript code/2_analysis/01_make_maps.R
 
-# make scatterplots
+echo "make scatterplots"
 stata -b do code/2_analysis/02_make_scatterplots.do
 
-# generate in-text statistics
+echo "generate in-text statistics"
 stata -b do code/2_analysis/03_intext_stats.do
 
-# delete log files
+echo "delete log files"
 rm 02_make_scatterplots.log
 rm 03_intext_stats.log
 rm 05_fill_tradedata.log

--- a/code/run.sh
+++ b/code/run.sh
@@ -15,7 +15,7 @@ pip install openpyxl
 # SET WORKING DIRECTORY HERE -----------------------------------------
 
 # insert the path of your working directory after "cd"
-cd /scratch/network/lcrews/ccn-water-PandP
+cd
 
 # CLEAN VIRTUAL WATER DATA -------------------------------------------
 


### PR DESCRIPTION
I tried to replicate from scratch on Princeton's cluster using `run.sh`, but I ran into a few problems. Logging them here.

- Need to clarify in "### Software requirements" that we do not provide installation scripts for packages and libraries. This was confusing because we have a directory for `0_env_setup`, which suggests we'll do all the installing for them. I think we should move `setup.R` into `2_analysis` as `00_setup.R` and delete `0_env_setup` entirely. (Side note: the R packages took ~30min to install... if this is expected, we should warn users.)
- Mismatch between Python software requirements and what gets installed in `run.sh`. Also, re: my previous bullet, it's weird to only install Python packages for the user and to do it here rather than in `0_env_setup`.
- In the crosswalk scripts, I get a warning (presumably with the fuzzy match) that I've never gotten in the main pipeline: `WARNING:root:Applied processor reduces input query to empty string, all comparisons will have score 0. [Query: '']`. We seem to get the same exact CSVs for the crosswalks, though, so I'm fine ignoring this.
- Cannot save file into a non-existent directory: `data/intermediate/production`. I've made this directory in Dropbox.
- No such file or directory: `data/input/crop_water_footprint/Report47-Appendix-II.xlsx`. I've added this file to Dropbox. I also added `water_intensity_per_tonne.csv`, which was missing.
- in the first R script: needed to create `results/` directory first
```
      Error in ggsave():
      ! Cannot find directory results.
      Please supply an existing directory or use create.dir=TRUE.
```

Once I got `run.sh` to run without errors, all the maps came out, and `intext_stats.xlsx` exists, but **I didn't get any of the scatter plots, and the Excel file only has two stats in it (see Dropbox)**. I didn't get any errors with `02_make_scatterplots.do` and `03_intext_stats.do`, but something must've gone wrong.